### PR TITLE
fix typeof check in Graph.js

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -290,7 +290,7 @@ Rickshaw.Graph = function(args) {
 
 		args = args || {};
 
-		if (typeof window !== undefined) {
+		if (typeof window !== 'undefined') {
 			var style = window.getComputedStyle(this.element, null);
 			var elementWidth = parseInt(style.getPropertyValue('width'), 10);
 			var elementHeight = parseInt(style.getPropertyValue('height'), 10);


### PR DESCRIPTION
This was incorrectly checking that typeof window was not undefined,
which will always return true, as typeof always returns a string.
